### PR TITLE
BOJ1037-약수

### DIFF
--- a/src/Math/BOJ1037.java
+++ b/src/Math/BOJ1037.java
@@ -1,0 +1,71 @@
+package Math;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+public class BOJ1037 {
+
+    /**
+     * 리스트 정렬을 사용한 방법
+     */
+    public static void useCollectionsSort() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        ArrayList<Integer> divisors = new ArrayList<>();
+
+        for(int i = 0; i<N; i++){
+            divisors.add(Integer.parseInt(st.nextToken()));
+        }
+
+        Collections.sort(divisors);
+        System.out.println(divisors.get(0) * divisors.get(N-1));
+
+    }
+
+    /**
+     * 배열 정렬을 사용한 방법
+     */
+    public static void useArraysSort() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int[] divisors = new int[N];
+
+        for(int i = 0; i<N; i++){
+            divisors[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(divisors);
+        System.out.println(divisors[0] * divisors[N-1]);
+    }
+
+    /**
+     * 정렬을 사용하지 않고 최소값 최대값을 사용하는 방법
+     */
+    public static void useMinMax() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int max = Integer.MIN_VALUE;
+        int min = Integer.MAX_VALUE;
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        while(N-->0){
+            int divisor = Integer.parseInt(st.nextToken());
+            max = Math.max(divisor, max);
+            min = Math.min(divisor, min);
+        }
+
+        System.out.println(min * max);
+    }
+    public static void main(String[] args) throws IOException {
+        BOJ1037.useMinMax();
+    }
+}


### PR DESCRIPTION
# TIL
## ERROR 😢
## KEYWORD 🔖
 - Collections.sort, Arrays.sort
 - N의 약수의 집합에서 N을 찾기 위해서는 가장 작은 약수와 가장 큰 약수를 곱하면 된다
 
## MINDFLOW 🤔 
1. 약수의 집합의 원소개수가 짝수인 경우 정렬 후 (arr[1] * arr[length-1]) 홀수인 경우 (arr[(length-1)/2 * arr[(length-1)/2]로 N을 찾아야 한다고 생각했다. 따라서 정렬이 불가피하다고 판단했다.
2. 하지만 약수의 집합의 원소개수가 홀수라도 (arr[1] * arr[length-1])로 N을 찾을 수 있으며, 약수의 개수가 1개인 경우도 (arr[1] * arr[length-1])로 N을 찾을 수 있다. 
3. 즉, 약수의 집합에서 최소값과 최대값만 알면 된다.

## PRACTICE 📖
 - N번만큼 반복하는 방법 : while(N-->0)
 - 정렬만 필요한 경우 성능 : Array.sort(배열) > Collections.sort(연결리스트)
   - 배열의 경우 연속된 메모리에 저장이 되어 접근 빠름)

## Issue link 🔄
 - close #5 

## Collections.sort vs Arrays.sort vs MinMax 🆚 
<img width="829" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/47ac2e02-da80-4bb1-b1b4-1ccaef330d13">

약수의 집합 원소의 개수가 50보다 작거나 같은 자연수로 매우 적다.

- Collections.sort, Arrays.sort :  시간 차이가 적고 심지어 역전된 모습을 보인다.
- MinMax : 배열이나 연결리스트를 사용하지 않아 메모리가 적게 사용되고 정렬이 필요하지 않으므로 시간이 빠르다.
