### PR TITLE
BOJ17425 - 약수의 합

### DIFF
--- a/src/Math/BOJ17425.java
+++ b/src/Math/BOJ17425.java
@@ -1,0 +1,65 @@
+package Math;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ17425 {
+
+    /**
+     * 배수를 이용하여 자연수 N이 주어질 때마다 g(n)을 구하는 방법
+     */
+    public static int countMultiples(int number){
+        int sum = 0;
+        for(int i=1; i<=number; i++){
+            sum += i * (number/i);
+        }
+        return sum;
+    }
+    public static void useCountMultiples() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+
+        while(N-->0){
+            sb.append(countMultiples(Integer.parseInt(br.readLine()))).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+    /**
+     * 배수를 이용하여 입력값의 최대인 1000000까지의 각각의 g(n)을 구해서 저장해 놓는 방법
+     */
+    static final int MAX = 1000000;
+
+    public static void useDivisorSumDP() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+
+        long fx[] = new long[MAX+1];
+
+        for(int i = 1; i<=MAX; i++){
+            for(int j = 1; i*j<=MAX; j++){
+                fx[i*j] += i;
+            }
+        }
+
+        for(int i = 2; i<=MAX; i++){
+            fx[i] += fx[i-1];
+        }
+        while(N-->0){
+            sb.append(fx[Integer.parseInt(br.readLine())]).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        useDivisorSumDP();
+    }
+}


### PR DESCRIPTION
# TIL
## ERROR 😢
## KEYWORD 🔖
- Java의 출력 성능 : StringBuilder > System.out.println()
- 배수를 사용하여 1개의 g(N)를 구하는 방법의 시간 복잡도 : $O(N)$
- 배수를 사용하여 M개의 g(N)를 구하는 방법의 시간 복잡도 :  $O(MN)$
    - N = 1,000,000 M = 100,000 으로 제한 시간 1초가 넘어가게된다.

- N까지의 g(N)을 구해서 배열에 저장 해 놓는 방법의 시간 복잡도 : $O(N\log{N})$
    1. 배수를 사용하여 각 인덱스의 f(i) 저장 : $O(N\log{N})$
    2. 이전 값을 활용하여 각 인덱스의 g(i) 저장 : $O(N)$

## MINDFLOW 🤔
1. 입력의 개수가 여러개이며 "BOJ-약수의 합 2"와 같이 배수를 사용하여 약수의 합을 구하는 방법 : 시간초과
2. "BOJ-나머지"와 같이 기존에 구한 값이 이후에 구한 값에 도움이 되는 방법을 생각 : 미구현
4. g(N)을 배열에 저장해 놓는 방법 : 참고 (https://codejb.tistory.com/5)

### 배수를 사용하여 입력값의 한계(1,000,000) 까지 각 자연수 $N$ 의 약수들의 합 $f(N)$을 구한다음, 1보다 작은 자연수의 약수들의 모든 합인 $g(1)$를 가지고 $f(N) + g(N-1)$ 통해  $g(N)$을 구하는 방법을 사용

![image](https://github.com/iampingu99/codingInterview/assets/154869950/87fdf8bc-577c-4564-8477-ad289a38ec7e)
![image](https://github.com/iampingu99/codingInterview/assets/154869950/07110656-ec51-4b2e-8f86-aefd17c662cf)


## REPACTORING 👍
- f(N), g(N) 배열을 모두 사용하지 않고 f(N)에서 g(N)을 만들 수 있으므로 사용하지 않을 수 있다. 

## RESULT 🆚
<img width="832" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/b0e51736-3a78-4237-a73a-19b519033fee">

- O(NM) 시간 복잡도의 방법은 1000억으로 1000초가 필요하므로 실패, O(N\log{N}) 시간복잡도의 방법은 성공하였다. 

## ISSUE :
- close #7 