### PR TITLE
BOJ2609 - 최대공약수와 최소공배수

### DIFF
--- a/src/Math/BOJ2609.java
+++ b/src/Math/BOJ2609.java
@@ -1,0 +1,41 @@
+package Math;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ2609 {
+
+    /**
+     * 재귀함수를 사용한 최대 공약수
+     */
+    public static int recursiveGCD(int a, int b){
+        int r = a % b;
+        if(r != 0) return recursiveGCD(b, r);
+        else return b;
+    }
+
+    /**
+     * 반복문을 사용한 최대 공약수
+     */
+    public static int interactiveGCD(int a, int b){
+        int r;
+        while((r = a % b) != 0){
+            a = b;
+            b = r;
+        }
+        return b;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int A = Integer.parseInt(st.nextToken());
+        int B = Integer.parseInt(st.nextToken());
+
+        int gcd = A > B ? interactiveGCD(A, B) : interactiveGCD(B, A);
+        int lcm = A * B / gcd;
+
+        System.out.println(gcd);
+        System.out.println(lcm);
+    }
+}


### PR DESCRIPTION
# TIL
## ERROR 😢
## KEYWORD 🔖
 - 유클리드호제법

## MINDFLOW 🤔
 - 최대공약수와 최소공배수의 공식을 사용
     - 유클리드 호제법 https://imkh.dev/algorithm-gcd-lcm

> ### 2개의 자연수 a, b(a > b)에 대해서 a를 b로 나눈 나머지가 r일 때, a와 b의 최대공약수는 b와 r의 최대공약수와 같다.

> ### a와 b의 최소공배수는 a와 b의 곱을 a와 b의 최대공약수를 나눈 것과 같다.
 
<img src="https://github.com/iampingu99/codingInterview/assets/154869950/2852d6dd-ed8a-4abc-99b9-8488f4c5dfda" width="50%" height="50%" />

## REPACTORING 👍
- 재귀함수를 사용하는 것보다 반복문을 사용하면 스택의 오버플로와 메모리 사용을 줄일 수 있다.
    -  복잡한 반복문의 경우 또는 재귀적인 특성이 있는 경우 재귀함수를 통해 가독성을 높일 수 있다.

## RESULT 🆚
<img width="832" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/739cf57a-2cb3-4b04-9b4d-c1ff223e692d">

- 두 개의 10,000 이하의 자연수로 재귀함수와 반복문의 방식의 성능이 차이나지 않는다.

## Issue link 🔄
 - close #8
  
