### PR TITLE
solve: 소수 구하기

### DIFF
--- a/src/Math/BOJ1929.java
+++ b/src/Math/BOJ1929.java
@@ -1,0 +1,35 @@
+package Math;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ1929 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+
+        int M = Integer.parseInt(st.nextToken());
+        int N = Integer.parseInt(st.nextToken());
+
+        Boolean[] isPrimeList = new Boolean[N+1];
+        isPrimeList[1] = false;
+
+        for(int i = 2; i <= N; i++){
+            if(isPrimeList[i] == null) isPrimeList[i] = true;
+            if(isPrimeList[i] == false) continue;
+            for(int j = i; j<= N/i; j++){
+                isPrimeList[i*j] = false;
+            }
+        }
+
+        for(int i = M; i<=N; i++){
+            if(isPrimeList[i]) sb.append(i).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL
## ERROR 😢
- ArrayIndexOutOfBounds
    - i * j 수의 표현 범위를 넘어가 i * j ≤ MAX 조건식을 통과하게 되고 isPrimeList[j * j] 배열의 범위를 넘어가서 발생하였다.

## KEYWORD 🔖
- N : 1,000,000 | time : 2s
- N이하의 소수를 구하는 시간 복잡도 : $O(N\sqrt{N})$
    
    1,000,000 * 1,000 = 1,000,000,000 $\sim$ 10s
    
- 배수를 사용해 소수를 구하는 시간 복잡도 : $O(N\log{N})$
    
    1,000,000 * 19 = 19,000,000 $\sim$ 0.19s
    
- 에라토스테네스의 체 시간 복잡도 : $O(N\log\log{N})$
    
    1,000,000 * 4 = 4,000,000 $\sim$ 0.04s
    

## MINDFLOW 🤔

1. O(N\sqrt{N})의 알고리즘을 사용할 수 없다. 
2. 약수의 합 풀이 방식 적용: 성공
    
    i의 j 배인 수는 소수가 될 수 없다. 즉, i*j 는 소수가 될 수 없다
    
    N의 최대값 이하의 소수를 모두 구해놓자
    

## REPACTORING 👍

1. 에라토스테네스의 체 (https://codejb.tistory.com/8)
    1. i*j 는 소수가 될 수 없는데, i보다 작은 j의 경우 이전 i에서 이미 검사했다.
2. 해당 문제는 입력이 하나로 작으므로 N의 최대값 이하의 소수를 모두 구해놓는 것보다 N을 받아서 구하는 것이 사용하는 메모리를 줄일 수 있다.
3. i * j 의 값이 커서 표현범위를 벗어나는 경우를 고려해야 한다.
    1. 해당 문제에서는  i * j ≥ MAX 보단 i ≥ MAX / j 를 사용해야 한다.

## RESULT 🆚

<img width="832" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/4db38af2-9f40-46bb-bee8-e5d673e9d223">

$O(N\log{N})$ 의 시간 복잡도에서 $O(N\log\log{N})$ 로, 메모리를 N으로 줄였다.

## ISSUE :
- close #10 
