### PR TITLE
BOJ6588 - 골드바흐의 추측

### DIFF
--- a/src/Math/BOJ6588.java
+++ b/src/Math/BOJ6588.java
@@ -1,0 +1,122 @@
+package Math;
+
+import java.io.*;
+import java.util.ArrayList;
+
+public class BOJ6588 {
+
+    private static final int MAX = 1000000;
+    private static boolean[] isPrime = new boolean[MAX + 1];
+    private static int[] primeArray = new int[MAX+1];
+    private static ArrayList<Integer> primeList = new ArrayList<>();
+
+    /**
+     * 에라토스테네스의 체
+     */
+    public static void sieveOfEratosthenes(){
+        for (int i = 2; i <= MAX; i++) {
+            isPrime[i] = true;
+        }
+
+        for (int i = 2; i <= Math.sqrt(MAX); i++) {
+            if (!isPrime[i]) continue;
+            for (int j = i*i; j <= MAX; j+=i) {
+                isPrime[j] = false;
+            }
+        }
+    }
+
+    /**
+     * 이진탐색 : N 탐색 실패시 N 보다 작은 값중 가장 큰 값 반환
+     */
+    public static int binarySearch(int key, int low, int high) {
+        int mid;
+
+        if(low <= high) {
+            mid = (low + high) / 2;
+
+            if(key == primeArray[mid]) {
+                return mid;
+            } else if(key < primeArray[mid]) {
+                return binarySearch(key ,low, mid-1);
+            } else {
+                return binarySearch(key, mid+1, high);
+            }
+        }
+
+        return low-1;
+    }
+
+    /**
+     * 소수 배열에서 N보다 작은 수 중 가장 큰 소수를 이진탐색으로 찾아 two point 로 A B 찾는 방법
+     */
+    public static void useTwoPoint() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        sieveOfEratosthenes();
+
+        int j = 0;
+        for(int i = 2; i<=MAX; i++){
+            if(isPrime[i]) primeArray[j++] = i;
+        }
+
+        int primeLength = j-1;
+
+        while(true){
+            int num = Integer.parseInt(br.readLine());
+            if(num == 0) break;
+
+            int end = binarySearch(num, 1, primeLength);
+            int start = 1;
+
+            while(start<=end){
+                int sum = primeArray[start] + primeArray[end];
+                if(sum == num) {
+                    sb.append(num).append(" = ").append(primeArray[start]).append(" + ").append(primeArray[end]).append("\n");
+                    break;
+                }
+                else if(sum < num) start++;
+                else end--;
+            }
+        }
+        System.out.println(sb);
+    }
+
+    /**
+     * 소수 배열에서 가장 작은 홀수부터 A를 시작하여 N - A = B의 값이 소수인지 확인하는 방법
+     */
+    public static void useOnePoint() throws IOException{
+        BufferedReader br = new BufferedReader(new FileReader("src/input.txt"));
+
+        //BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        sieveOfEratosthenes();
+
+        int j = 0;
+        for(int i = 2; i<=MAX; i++){
+            if(isPrime[i]) primeList.add(i);
+        }
+
+
+        while(true) {
+            int num = Integer.parseInt(br.readLine());
+            if(num == 0) break;
+
+            for(int i = 1; i <= primeList.size()/2; i++) {
+                int a = primeList.get(i);
+                //N - A = B가 소수인지 확인
+                if(isPrime[num - a]) {
+                    sb.append(num).append(" = ").append(a).append(" + ").append(num-a).append("\n");
+                    break;
+                }
+            }
+        }
+        System.out.println(sb);
+    }
+
+    public static void main(String[] args) throws IOException {
+        useOnePoint();
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- 에라토스테네스의 체 : $O(N\log\log{N})$
- N을 배열의 두 원소 A B의 합으로 나타낼 때, 두 원소의 차가 가장 큰 쌍을 구하는 방법
    1. tow-point 사용
    A는 배열의 시작부터 증가하는 인덱스(start) 원소, B는 배열의 끝부터 감소하는 인덱스(end) 원소로 A) + B == N 인지 검사
    2. one-point 사용
    B-A 가 가장 크다 = N-A 가 가장 크다로 소수 배열의 시작부터 증가하는 인덱스(start)만 가지고 N-A 즉, B 가 소수인지 검사

## MINDFLOW 🤔

1. N ≤ 1,000,000 의 범위를 가지는 입력이 100,000개 이므로 입력에 대한 결과를 미리 저장해놓아야 한다. N보다 작은 소수를 모두 저장하는 에라토스테네스의 체를 사용한다. 
2. A B의 차가 가장 커야 하므로 two-point를 이용할 수 있다 : 성공
    1. start 배열의 시작부터 증가하는 인덱스, end 배열의 끝부터 감소하는 인덱스
    2. N보다 작으면서 가장 큰 소수를 가리킬 인덱스 end를 찾는데 시간복잡도가 O(N)이 발생하였다.
    3. 이진탐색 알고리즘을 사용해서 end를 찾는데 O(logN)으로 줄였다.
    4. 소수의 개수를 모르므로 연결리스트가 적합해 보이나, 이진탐색을 위해 배열을 사용해야 하며, 배열의 크기를 크게 잡을 수 밖에 없고, 나머지 공간이 낭비되면서 원소가 들어가있는 곳을 찾아야 한다는 문제점이 있다.

## REPACTORING 👍

1. 배열의 size() 와 배열의 끝 인덱스는 다르다 → 배열 속성을 함수 매개변수로 사용할 때 size()와 끝 인덱스를 구분해야 한다.
2. Boolean 과 boolean은 다르다. Boolean은 래퍼클래스로 null을 가질 수 있다. 따라서 초기화시 null로 초기화된다. boolean은 null을 가지지 못한다. 따라서 초기화시 false로 초기화된다. 이점을 잘 활용할 수 있어야 할 것이다.
3. B-A 가 크면 되므로 A를 가장 작은 소수부터 늘려나가며 N-A = B 가 소수인지 확인한다 (https://codejb.tistory.com/9)
    증가하는 인덱스만 필요하므로 배열 대신 연결리스트를 사용하여 공간을 맞게 쓸 수 있다.
    

## REPORT ✏️

차가 가장 큰 A B 쌍을 구하는데 투 포인터가 빠르다고 생각하고 코드를 작성했지만 많은 실패를 마주했다. 투 포인터가 사실은 차가 가장 큰 A B 쌍을 못구하는게 아닌가 싶어 시나리오를 생각해보았지만 떠오르지 않았다. 

알고보니 에라토스테네스의 체 구현의 for 코드가 문제였다. 더 직관적인 방식으로 코드를 변경하다보니 범위를 이해하지 못하였다. → 코드가 미세하게 다를 때 왜 둘 다 가능한지 생각해보자.

이후에는 시간초과가 발생하였는데, end 포인터를 찾는데 O(N)의 시간 복잡도가 드는 것을 발견하였다. 이에 이진탐색 알고리즘을 통해서 해결하였다. 

> 
/마지막으로 one, two-point 방식 모두 A과 B를 찾는데는 같은 시간 복잡도 O(N)을 가지는 것으로 보이는데 이때 전체 시간 복잡도가 O(MN)로 시간초과가 발생해야 하지만 그렇지 않다. 아마 해당 이론은 참으로 추정되고 있고, A B 쌍을 찾는데 몇번의 반복이면 찾기 때문으로 보인다.
> 

## RESULT 🆚
<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/ca7ee1a9-45c7-42fc-9e46-993b59425d94">

1. 배열의 two-point
2. 연결리스트의 one-point

## ISSUE
- close #11 