### PR TITLE
BOJ1476 - 날짜 계산

### DIFF
--- a/src/BruteForce/BOJ1476.java
+++ b/src/BruteForce/BOJ1476.java
@@ -1,0 +1,45 @@
+package BruteForce;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ1476 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int E = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        if(E == 15) E = 0;
+        if(M == 19) M = 0;
+
+        for(int i = S;; i+=28){
+            if(i%15 == E && i%19 == M){
+                System.out.println(i);
+                break;
+            }
+        }
+
+//        int result = 1;
+//        int i = 1;
+//        int j = 1;
+//        int k = 1;
+//        while(true){
+//            if(i == E && j == S && k == M) {
+//                System.out.println(result);
+//                break;
+//            }
+//            result++;
+//            i++;
+//            j++;
+//            k++;
+//            if(i == 16) i = 1;
+//            if(j == 29) j = 1;
+//            if(k == 20) k = 1;
+//        }
+
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. Brute-Force : O(N)
2. 나머지 연산

## MINDFLOW 🤔

1. Brute-Force 로 구현하였으나 코드 문제로 시간초과가 발생했다.
2. 1씩 증가하지 않고 가장 큰 수인 28씩 증가하도록 하였다.

## REPACTORING 👍

1. 모든 경우를 검사하지 않고도 도출한다면 조금의 시간을 단축할 수 있을 것이다. → 1씩 증가하는 것보다 28씩 증가하도록 하였다.

## REPORT ✏️

- 시간 초과가 발생하였다고 해당 알고리즘이 정상적으로 동작하지만 시간이 초과했다는 것으로 이해했다. 하지만 시간초과는 실행을 중간에 중단했기 때문에 맞았는지 틀렸는지 알 수가 없다고 한다. [[백준 - 자주묻는 질문]](https://help.acmicpc.net/faq)
- 나머지 연산의 범위로 인해 발생한 문제였는데, 나머지 연산은 0을 표현한다는 점에 유의해야 한다. 1≤ N ≤ 15 인 경우 16으로 나눈 나머지 0 ≤ N ≤ 15 를 생각할 수 있고, 15로 나눈 나머지 0 ≤ N ≤ 14 를 생각할 수 있다. 이때 범위가 같은 15로 나눈 나머지를 사용해야 한다. 0을 15로 표현하는 과정이 필요할 것이다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/6f0c7d8b-2b3d-4e86-8f44-587fc34e11c2">

- 1보다는 28씩 검사하는 것이 조금의 시간을 단축하였다.

## ISSUE

- close #25 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment