### PR TITLE
BOJ1107 - 리모컨

### DIFF
--- a/src/BruteForce/BOJ1107.java
+++ b/src/BruteForce/BOJ1107.java
@@ -1,0 +1,45 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ1107 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int M = Integer.parseInt(br.readLine());
+
+        boolean[] isBroken = new boolean[10];
+
+        if(M>0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            while(M-->0){
+                isBroken[Integer.parseInt(st.nextToken())] = true;
+            }
+        }
+
+        int min = Math.abs(N - 100); //현재 채널은 100번
+        int i, j;
+
+        //완전 탐색
+        for(i = 0; i<1000000; i++){
+            String s = String.valueOf(i); //숫자의 특정 자리에 접근하기 위해 문자열로 변환
+
+            for(j = 0; j<s.length(); j++){ //채널의 특정 자리 숫자가 고장난 버튼인지 확인
+                if(isBroken[s.charAt(j) - '0']){
+                    break;
+                }
+            }
+
+            if(j==s.length()){ //이동가능한 채널인 경우
+                min = Math.min(Math.abs(N-i)+s.length(), min); //해당 채널로 이동 후, + 또는 -만을 사용하여 이동
+            }
+        }
+        System.out.println(min);
+    }
+
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. Brute-Force 
2. N과 가장 가까운 수 찾기

## MINDFLOW 🤔

1. 주어진 숫자로 N과 가장 가까운 곳으로 이동한 다음 + 또는 -만 사용하여 움직일 수 있다는 점을 생각하지 못했다. : 실패
    - N과 가장 가까운 곳으로 이동하고 또 이동할 수 있는 것으로 이해했다. 즉, 500,000 채널을 1과 5의 숫자만으로 움직일 때 511,111로 이동하고 -11,111으로 12번의 버튼을 눌러야 하는 줄 알았다.
    - 따라서 매번 주어진 숫자로 가장 가까운 곳으로 이동한다고 이해하여 로직을 만들기 어려워 포기하게 되었다.
2. N과 가장 가까운 수 찾기 : 성공
    - 다른 풀이를 참고하여 N과 가장 가까운 수만 찾으면 된다는 것을 이해했다. (https://moonsbeen.tistory.com/64)

## REPACTORING 👍

- 문자열 메서드
    - 숫자를 문자열로 만드는 방법으로 String.valueOf()를 사용할 수 있다.
    - 문자열의 숫자를 자리별로 접근하는 방법으로 String.chartAt()을 사용할 수 있다.
    - %10연산 자리수를 구하지 않아도 length()로 구할 수 있으며 분리해서 배열의 원소로 넣지 않아도 인덱스로 접근할 수 있다.
- 숫자 0의 아스키코드는 48로 배열의 인덱스 0으로 사용할 경우 - 48 또는 - ‘0’ 을 해주어야 한다.

### sudo-code

- 모든 채널 경우의 수에서 이동할 수 있는 채널을 찾는다.
    - 0~999,999 까지에서 N과 가장 가까운 수를 찾는다. 최대 N이 500,000으로, 9만 고장나지 않은 경우 최대 이동할 채널은 999,999이기 때문이다.
    - 해당 채널 내부에 고장난 버튼이 있는 경우 이동 불가
- 해당 채널이 이동가능하다면 이동해야할 채널까지의 버튼 입력 수를 구하고 그중에서 최소값을 찾는다.

## REPORT ✏️

- 문제를 제대로 이해한 것이 맞는지 모든 예제 입력과 출력을 확인해보아야 할 것이다. 섵불리 문제를 이해하고 코드를 짯을 때 풀리지 않고, 다른 풀이를 보더라도 이해가되지 않는다.
- Brute-Force 의 경우 모든 경우의 수를 먼저 생각해보자.
    - 주어진 수로 경우의 수를 만드는 것과 모든 경우의 수를 찾는 것이 차이가 없을 수 있다.
    - 0~9로 이루어진 집합에서 순열의 모든 경우의 수는 자연수이다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/a4c2d6d8-ccc8-421f-9783-a89167d4cda5">

## Issue link 🔄
 - close #26 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment
