### PR TITLE
BOJ6064 - 카잉 달력

### DIFF
--- a/src/BruteForce/BOJ6064.java
+++ b/src/BruteForce/BOJ6064.java
@@ -1,0 +1,46 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ6064 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st;
+        int T = Integer.parseInt(br.readLine());
+
+        while(T-->0){
+            st = new StringTokenizer(br.readLine());
+            int N = Integer.parseInt(st.nextToken());
+            int M = Integer.parseInt(st.nextToken());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            if(y == M) y = 0;
+
+            int i;
+            for(i = x; i <= lcm(N, M) ; i+= N){
+                if(i % M == y) {
+                    System.out.println(i);
+                    break;
+                }
+            }
+            if(i > lcm(N, M)) System.out.println("-1");
+        }
+    }
+
+    public static int lcm(int a, int b){
+        return a * b / gcd(a, b);
+    }
+
+    public static int gcd(int a, int b){
+        int r;
+        while((r = a % b) != 0){
+            a = b;
+            b = r;
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. BOJ1476 - 날짜계산 풀이

## MINDFLOW 🤔

1. x, y의 공배수 내에서 나머지가 같을 때 출력하자 : 성공
    - 이전 문제에서 기존 풀이는 1씩 증가하였지만, REPACTORING으로 N씩 증가하도록 수정한 노력으로 시간 초과가 발생하지 않았다.

## REPACTORING 👍

1. 중국인의 나머지 정리 → 조건문을 (i-y) % M == 0 로 변경하면 성능이 좋아진다. : 이해불가

## REPORT ✏️

- 이전 문제를 풀면서 1≤ x ≤15까지의 수를 표현하기 위해 15로 나눈 나머지를 사용하며 15를 표현하기 위해 0를 사용하는 것을 알고 적용했다. 다른 방식으로는 0~14로 매핑하기 위해 x값을 -1을 하여 계산하고 결과값 i 에 +1 하는 방법도 있다.
- 비슷한 문제를 푼지 얼마되지 않았고 푼 문제를 정리해놓고 코드를 개선하려는 노력 덕분에 쉽게 푼 것 같다.

## RESULT 🆚
<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/9160c16a-7c38-48e4-9866-b282d9abaeec">

- 중국인의 나머지 정리로 조건문 하나 바꿨을 뿐인데 시간이 단축되었다. 하지만 왜 해당 식이 나오는지는 이해하지 못했다.
## ISSUE 🔄

- close #29 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment

