### PR TITLE
BOJ1748 - 수 이어 쓰기 1

### DIFF
--- a/src/BruteForce/BOJ1748.java
+++ b/src/BruteForce/BOJ1748.java
@@ -1,0 +1,26 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ1748 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String N = br.readLine();
+        int temp = 0;
+        long result = 0;
+        double count = 0;
+        int i;
+
+        for(i  = 1; i < N.length(); i++){
+            count = Math.pow(10, i) - Math.pow(10, i-1); //9 90 900 ...
+            temp += count;
+            result += count * i; //자리수 만큼 곱해서 더함
+        }
+        result += (Integer.parseInt(N) - temp) * i; //N - temp 만큼 마지막 자리수를 곱해서 더함
+
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖
- N까지의 모든 수의 자리 수 합 구하기

## MINDFLOW 🤔

1. 1 ≤ N ≤ 100,000,000 으로 O(N) 알고리즘은 아슬아슬 할 것 같아 최적화를 시도하였다. : 성공

    시간제한을 1초로 여기고 생각해낸 방법으로 실제 시간제한은 0.15 였다.

## REPACTORING 👍

- 통과를 위한 최적화 → O(N) 이 아닌 O(N.length())로 줄였다.

### sudo-code

1. N의 자리수 -1 만큼 반복한다.
3. 1의 자리의 경우 합은 (0~9) 개로 9 * 1 이다.
4. 10의 자리의 경우 합은 (10~99) 개로 90 * 2 이다.
5. 반복문을 빠져나오면 남은 (N에서 합을 구한 숫자를 제외한 수) 개 * (n의 자리수) 이다.
  즉, 120의 경우 (9 * 1) + (90 * 2) + (120-(9+90)) * 3 으로 252가 된다

## REPORT ✏️

- 다른 풀이의 경우 O(N) 알고리즘으로도 통과하였다. 1씩 증가하면서 10의 배수가 될 때 길이를 늘려주는 방식을 사용하였다. - 이는 채점기준이 바뀌기 이전으로 현재 시간제한은 0.15초이다. 따라서 O(N) 알고리즘을 사용하면 시간초과가 발생한다. 앞으로는 시간을 더 주의깊게 보아야 할 것이다.
- 여러번의 디버깅을 통해서 비로소 동작하게 되었다. 앞으로는 구현하고 디버깅 보다는 sudo코드를 먼저 구성하는 것이 시간을 줄일 수 있다는 것을 명심해야 한다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/6e0896cd-e4a4-4672-b8d6-35ae67258c90">

O(N) 알고리즘은 시간초과가 발생한다

## ISSUE 🔄

- close #28 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment