### PR TITLE
BOJ15649 - N과 M (1)

### DIFF
--- a/src/BruteForce/BOJ15649.java
+++ b/src/BruteForce/BOJ15649.java
@@ -1,0 +1,44 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ15649 {
+
+    public static StringBuilder sb;
+    public static boolean[] visited;
+    public static int[] arr;
+
+    public static void sequence(int depth, int n, int m){
+        if(depth == m){
+            for(int i = 0; i<m; i++){
+                sb.append(arr[i]).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+        for(int i = 0; i<n; i++){
+            if(visited[i]) continue;
+            visited[i] = true;
+            arr[depth] = i+1;
+            sequence(depth+1, n, m);
+            visited[i] = false;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        sb = new StringBuilder();
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        arr = new int[M];
+        visited = new boolean[N];
+
+        sequence(0, N, M);
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. DFS
2. N까지의 자연수 집합에서 수열 모두 출력

## MINDFLOW 🤔

1. 조합에 대한 알고리즘이 생각나서 방문/미방문을 사용한 DFS방식을 적용하려 했다.
    
    조합의 경우 순서가 상관없으므로 현재 인덱스의 이후 원소들에 대해서 선택/미선택하지만 수열의 경우 순서가 상관있으므로 현재 인덱스의 이전 원소들도 선택/미선택해야 한다.
    

## REPACTORING 👍

1. 재귀함수를 호출하더라도 변하지 않는 변수이 존재하였다. →  전역변수로 선언하여 코드가 깔끔해졌다.
2. 출력이 더 많아졌을 때를 대비해야 한다 → System.out.pintln보다는 StringBuilder를 사용하며 전역변수도 고려할 수 있다.

### sudo-code

종료조건 : M개를 선택한 경우

- 1을 선택 {2, 3, 4}
    - 2를 선택 탈출 {1, 2}
    - 3을 선택 2 4 탈출 {1, 3}
    - 4를 선택 2 3 탈출 {1, 4}
- 2를 선택 {1, 3, 4}
    - 1을 선택 3 4 재귀 탈출 {2, 1}
    - …

## **REPORT ✏️**

- sudo 코드를 사용하여 디버깅을 통해서 코드를 고치다보니 결국 풀어냈다. 이전에 푼 문제들이 점점 도움이 되는 것이 느껴진다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/dbed14f5-b01d-4cbb-8305-d3868b95c19f">

- System.out.print과 StringBuilder의 속도를 명확하게 확인할 수 있다.

## ISSUE 🔄

- close #40 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment