### PR TITLE
BOJ15650 - N과 M (2)

### DIFF
--- a/src/BruteForce/BOJ15560.java
+++ b/src/BruteForce/BOJ15560.java
@@ -1,0 +1,58 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ15560 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N,M;
+    public static int[] arr;
+
+    public static void useRecursive(int depth, int r){
+        if(depth == M){
+            for(int i = 0; i< M; i++){
+                sb.append(arr[i]).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+        if(r == N) return;
+
+        arr[depth] = r+1;
+        useRecursive(depth+1, r+1);
+        useRecursive(depth, r+1);
+    }
+
+    public static void useBackTracking(int depth, int r){
+        if(depth == M){
+            for(int i = 0; i< M; i++){
+                sb.append(arr[i]).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = r; i<N; i++){
+            arr[depth] = i+1;
+            useBackTracking(depth+1, i+1);
+        }
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        arr = new int[M];
+
+        useRecursive(0, 0);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. N까지의 자연수 집합에서 수열 집합 중 오른차순 집합만 출력 = 조합 
    1. 재귀함수
    2. 백트래킹 (https://st-lab.tistory.com/115)

## MINDFLOW 🤔

1. 순서가 중요하지 않은 순열은 조합이므로 조합을 구하는 알고리즘 중 재귀를 사용하는 방식을 사용했다.
2. 원소가 오름차순으로 나타나야 하므로 기존 배열을 정렬하는 코드가 필요할 수 있다. 하지만 기존 배열은 정렬되어 있다.

## REPACTORING 👍

### sudo-code

종료조건 : M개를 선택한 경우

- 1을 선택 {2, 3, 4} → 그다음 원소부터
    - 2 선택 → 종료 {1, 2}
    - 3 선택 → 종료 {1, 3}
    - 4 선택 → 종료 {1, 4}
- 2를 선택 {1, 3, 4} → 그다음 원소부터
    - 3 선택 → 종료 {2, 3}
    - …

## **REPORT ✏️**

- 조합을 구하는 알고리즘이 두가지가 있다는 것을 알고 있었다. 하지만 왜 boolean 배열을 선언하여 방문/미방문을 체크하는지에 대해서 알지 못했다. 조합은 순서가 중요하지 않으므로 이전의 원소는 고려하지 않아도 되기 때문이다. 고민끝에 조합 집합을 출력하기 위해서 필요한 것이라고 결론을 내렸다.
- 백트래킹방식을 잘 모르겠다. 백트래킹 문제가 나온다면 그때 알아보자.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/d165b3fd-e96e-4280-8794-c1a48f129577">

- 재귀함수와 백트래킹의 성능차이가 거의 없었다.

## ISSUE 🔄

- close #41 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment