### PR TITLE
solve: N과 M (3)

### DIFF
--- a/src/BruteForce/BOJ15651.java
+++ b/src/BruteForce/BOJ15651.java
@@ -1,0 +1,42 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ15651 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N,M;
+    public static int[] arr;
+
+    public static void duplicatePermutation(int depth){
+        if(depth == M){
+            for(int val : arr){
+                sb.append(val).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = 0; i<N; i++){
+            arr[depth] = i+1;
+            duplicatePermutation(depth + 1);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        arr = new int[M];
+
+        duplicatePermutation(0);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. 중복순열 - 백트래킹

## MINDFLOW 🤔

1. 수열 알고리즘에서 중복이 되도록 visited를 사용하지 않으면 될 것이다.

## REPACTORING 👍

### sudo-code

종료조건 : M개를 선택한 경우

- 1을 선택 {1, 2, 3, 4} 모든 원소 선택가능 (중복)
    - 1 선택 → 종료 {1, 1}
    - 2 선택 → 종료 {1, 2}
    - 3 선택 → 종료 {1, 3}
    - 4 선택 → 종료 {1, 4}
- 2를 선택 {1, 2, 3, 4} 모든 원소 선택가능 (중복)
    - 1 선택 → 종료 {2, 1}
    - 2 선택 → 종료 {2, 2}
    - …

## **REPORT ✏️**

- 배열을 사용해서 그런지 재귀함수를 사용하더라도 DFS bubble sort와 같이 반복문으로 전체 인덱스에 접근하는 것처럼 느껴진다. 맞는 접근 방법인지는 모르겠다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/ca64f592-0df5-42c6-a95a-f62df58b661e">

## ISSUE 🔄

- close #42 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment