### PR TITLE
solve: N과 M (4)

### DIFF
--- a/src/BruteForce/BOJ15652.java
+++ b/src/BruteForce/BOJ15652.java
@@ -1,0 +1,42 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ15652 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N, M;
+    public static int arr[];
+
+    public static void duplicatePermutationASC(int depth, int r){
+        if(depth == M){
+            for(int val : arr){
+                sb.append(val).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = r; i<N; i++){
+            arr[depth] = i+1;
+            duplicatePermutationASC(depth + 1, i);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        arr = new int[M];
+
+        duplicatePermutationASC(0, 0);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. N까지의 자연수 중 M개를 고르는 중복순열 집합 중 오름차순

## MINDFLOW 🤔

1. 기존 오름차순 순열(이후 인덱스 선택)에서 선택한 인덱스를 포함하는 방법을 사용하였다.

## REPACTORING 👍

### sudo-code

종료조건 : M개를 선택한 경우

- 1을 선택 {1, 2, 3, 4} 선택한 인덱스를 포함한 이후 인덱스를 선택
    - 1 선택 → 종료 {1, 1}
    - 2 선택 → 종료 {1, 2}
    - 3 선택 → 종료 {1, 3}
    - 4 선택 → 종료 {1, 4}
- 2를 선택 {1, 2, 3, 4} 선택한 인덱스를 포함한 이후 인덱스를 선택
    - 2 선택 → 종료 {2, 2}
    - 3 선택 → 종료 {2, 3}

## **REPORT ✏️**

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/25bb8982-6512-478e-8416-413606490928">

## ISSUE 🔄

- close #43 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment