### PR TITLE
BOJ15654 - N과 M (5)

### DIFF
--- a/src/BruteForce/BOJ15654.java
+++ b/src/BruteForce/BOJ15654.java
@@ -1,0 +1,56 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ15654 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N, M;
+    public static int base[];
+    public static int arr[];
+    public static boolean visited[];
+
+    public static void permutation(int depth){
+        if(depth == M){
+            for(int val : arr){
+                sb.append(val).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+        for(int i = 0; i<N; i++){
+            if(visited[i]) continue;
+            visited[i] = true;
+            arr[depth] = base[i];
+            permutation(depth + 1);
+            visited[i] = false;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        base = new int[N];
+        arr = new int[M];
+        visited = new boolean[N];
+
+        st = new StringTokenizer(br.readLine());
+
+        for(int i = 0; i<N; i++){
+            base[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(base);
+
+        permutation(0);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. N까지의 자연수의 집합 중 M개를 고르는 순열 집합 중 오름차순

## MINDFLOW 🤔

1. 순열 알고리즘에서 자연수의 집합 변수를 추가하여 사용하였다.

## REPACTORING 👍

### sudo-code

## REPORT ✏️

- 출력을 위해서 고른 원소를 arr 배열에 넣게 되는데, visited 배열이 있다면 true인 인덱스의 값만 출력할 수 있으면 같지 않을 까 생각했다. 하지만 출력시 visited 배열의 처음부터 출력하게 되므로 2번째 원소를 고르고 1번째 원소를 고름에도 불구하고 1번째 원소가 먼저 출력 되어 1번째 원소를 고르고 2번째 원소를 고른 출력과 같게 된다. 따라서 visited 배열 만으로는 출력하기 어렵다.

## RESULT 🆚
<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/ff4c71e8-9534-4b93-833e-38a02c8aabcd">


## ISSUE 🔄

- close #44 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment