### PR TITLE
BOJ15655 - N과 M (6)

### DIFF
--- a/src/BruteForce/BOJ15655.java
+++ b/src/BruteForce/BOJ15655.java
@@ -1,0 +1,55 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ15655 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N, M;
+    public static int base[];
+    public static boolean visited[];
+
+    public static void permutationASC(int depth, int r){
+        if(depth == M){
+            for(int i = 0; i<N; i++){
+                if(visited[i]) sb.append(base[i]).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = r; i<N; i++){
+            if(visited[i]) continue;
+            visited[i] = true;
+            permutationASC(depth + 1, i + 1);
+            visited[i] = false;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        base = new int[N];
+        visited = new boolean[N];
+
+        st = new StringTokenizer(br.readLine());
+
+        for(int i = 0; i<N; i++){
+            base[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(base);
+
+        permutationASC(0, 0);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. N까지의 자연수의 집합 중 M개를 고르는 순열 집합 중 오름차순인 수열만 출력

## MINDFLOW 🤔

1. 순열 집합 중 오름차순 수열 출력 코드에서 N까지의 자연수 집합을 입력받기 위한 배열 변수를 추가했다.

## REPACTORING 👍

- 오름차순인 수열만을 출력하므로 순서가 중요하지 않다. → 출력하기 위한 새로운 배열 변수를 사용하지 않고도 visited[] 만으로도 출력할 수 있다.

### sudo-code

1. 수열을 입력 받는다 : base[]
2. 정렬한다.
3. 선택한 인덱스보다 큰 인덱스만 선택할 수 있다. : r
4. 중복을 허용하지 않으므로 선택된 인덱스는 넘어간다 : visited[]

## REPORT ✏️

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/c7598bf5-49ea-481e-af46-f164ade18ced">

## ISSUE 🔄

- close #45 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment