### PR TITLE
BOJ15657 - N과 M (8)

### DIFF
--- a/src/BruteForce/BOJ15657.java
+++ b/src/BruteForce/BOJ15657.java
@@ -1,0 +1,50 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ15657 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N,M;
+    public static int[] base;
+    public static int[] arr;
+
+    public static void duplicatePermutationASC(int depth, int r){
+        if(depth == M){
+            for(int val : arr){
+                sb.append(val).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = r; i<N; i++){
+            arr[depth] = base[i];
+            duplicatePermutationASC(depth+1, i);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        base = new int[N];
+        arr = new int[M];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<N; i++){
+            base[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(base);
+        duplicatePermutationASC(0, 0);
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. N까지의 자연수의 집합 중 M개를 고르는 중복순열 집합 중 오름차순으로 오름차순인 수열만 출력

## MINDFLOW 🤔

1. 중복순열 집합을 오름차순으로 오름차순인 수열만 출력하는 코드에서 N개의 원소를 입력받기 위한 배열 변수를 추가했다.

## REPACTORING 👍

### sudo-code

1. 수열을 입력 받는다 : base[]
2. 오름차순으로 선택하기 위해 정렬한다.
3. 선택한 순서대로 저장한다 : arr[]
    - 현재 인덱스의 값보다 크거나 같은 원소만 선택할 수 있다. : r

## REPORT ✏️

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/956bd96f-0bec-405f-85b2-64f71da6f9a5">

## ISSUE 🔄

- close #47 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment