### PR TITLE
solve: NM과 K (1)

### DIFF
--- a/src/BruteForce/BOJ18290.java
+++ b/src/BruteForce/BOJ18290.java
@@ -1,0 +1,64 @@
+package BruteForce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ18290 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N, M, K;
+    public static int[][] matrix;
+    public static boolean[][] visited;
+    public static int[] dx = {-1, 1, 0, 0};
+    public static int[] dy = {0, 0, -1, 1};
+    public static int MAX = Integer.MIN_VALUE;
+
+    public static void matrixPermutation(int row, int col, int sum, int k){
+        if(k == K){
+            MAX = Math.max(MAX, sum);
+            return;
+        }
+
+        for(int i = row; i<N; i++){
+            for(int j = (i == row) ? col : 0; j<M; j++){
+                if(isAdj(i, j)) continue;
+                visited[i][j] = true;
+                matrixPermutation(i, j+1,sum + matrix[i][j], k+1);
+                visited[i][j] = false;
+            }
+        }
+    }
+
+    public static boolean isAdj(int row, int col){
+        for(int i = 0; i<4; i++){
+            int newRow = row + dx[i];
+            int newCol = col + dy[i];
+            if(newRow >= N || newCol >= M || newRow < 0 || newCol < 0) continue;
+            if(visited[newRow][newCol]) return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        matrix = new int[N][M];
+        visited = new boolean[N][M];
+
+        for(int i = 0; i<N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        matrixPermutation(0, 0, 0, 0);
+        System.out.println(MAX);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

1. 행렬에서의 M개를 고르는 수열의 집합 → 조합 

## MINDFLOW 🤔

1. 테트로미노 문제가 떠올라 적용하려 했다. 대각선 인덱스만 고르는 DFS를 구현했다 : 실패
    - 대각선 인덱스만 고르는 것이 아닌, 인접하지만 않는 인덱스는 모두 고를 수 있다
2. 모든 조합을 구하여 인접하지 않는 수열의 집합의 합을 구하였다 : 시간초과
    - 고르는 순서와 합은 관계 없으므로 조합알고리즘을 사용할 수 있다.
    - 하나의 수열 집합당 인접하는지 확인하므로 시간이 오래 걸렸다.
3. 앞으로 고를 인덱스만 인접하는지 확인하여 구하였다(https://today-retrospect.tistory.com/172)

## REPACTORING 👍

- 처음 풀이와 참고한 코드는 이미 고른 수열을 또 고르게 된다. -> 고른 수열은 고르지 않도록 반복문을 잘 구성했다.

### sudo-code

일차원 배열에서 조합을 출력하는 알고리즘에서 이차원 배열로 확장한다.

- 현재 인덱스 보다 큰 인덱스만 고를 수 있도록 한다 : row, col
- 열에 끝에 도달한 경우 다음 행으로 갈 수 있도록 한다.
- 인접한 인덱스를 고르지 않도록 고른 인덱스를 표시한다 : visited[]

## REPORT ✏️

- 테트로미노 문제에서 배운점을 잘 적용했다. 하지만 문제를 잘못이해하여 틀리게되었다.
- 앞으로 고를 인덱스만 인접하는지 확인하면 되는데, 이전에 고른 인덱스들에 대해 모두 확인해야하지 않나는 생각에 Coord 객체를 만들어 적용하기도 했다. 왜 그런 생각을 했는지 모르겠다. 재귀함수의 과정을 잘못 생각한듯 하다. 디버깅을 좀더 열심히 해봐야겠다.
- 첫번째 방식(테트로도미노와 비슷한 코드)에서 열에 끝에 다다른 경우 다음 열로 가도록 하는 방식을 잘 적용해놓고 두번째 방식(순열과 비슷한 코드)에서 헤매었다. 첫번째 방식의 코드에 이유가 없던 탓이었던 것 같다.
    - 처음 코드에서 필요없는 반복을 하는 것 같아 리팩토링하려 했다. 또한 참고한 코드도 필요없는 반복을 하는 것 같아 리팩토링하려 했다. 오래 걸렸지만 질문글에 반례도 달아줄 정도로 이해했다.
    - 열에 끝에 도달하더라도 재귀호출에는 신경쓰지 않아도되는 것이, 반복문의 조건문에 걸리게 된다. 즉, 반복문을 신경써야 한다.

## RESULT 🆚

<img width="831" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/f7b56bc6-0b31-4000-b3a1-e7e6f5db50ce">

## ISSUE 🔄

- close #49 

# CHECK-LIST

- [ ]  REPACTORING comment
- [ ]  REPORT comment