### PR TITLE
BOJ1759 - 암호 만들기

### DIFF
--- a/src/BruteForce/Recursive/BOJ1759.java
+++ b/src/BruteForce/Recursive/BOJ1759.java
@@ -1,0 +1,56 @@
+package BruteForce.Recursive;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ1759 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int L, C;
+    public static char base[];
+    public static char arr[];
+
+    public static void passwd(int depth, int r, int count){
+        if(depth == L){
+            if(count < 1 || depth - count < 2) return; //모음이 1개 미만, 전체길이 - 2 초과인 경우 조건 미충족
+            for(char c : arr){
+                sb.append(c);
+            }
+            sb.append('\n');
+            return;
+        }
+
+        for(int i = r; i < C; i++){
+            arr[depth] = base[i];
+            if(isVowels(base[i])) passwd(depth + 1, i + 1, count+1); //모음인 경우 count 증가
+            else passwd(depth + 1, i + 1, count); //자음인 경우 유지
+        }
+    }
+
+    public static boolean isVowels(char c){
+        if(c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u') return true;
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        L = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        base = new char[C];
+        arr = new char[L];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<C; i++){
+            base[i] = st.nextToken().charAt(0);
+        }
+
+        Arrays.sort(base);
+        passwd(0, 0, 0);
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- 서로다른 C개의 문자 중에서 L개를 중복이 불가능하게 고르는 문자열중 최소 한개이상의 모음, 두개이상의 자음으로 이루어진 문자열을 오름차순으로 출력 : 조합

## MINDFLOW 💬

1. 백트래킹 조합 알고리즘에서 한개 이상의 모음 두개 이상의 자음을 확인하는 함수를 추가하였다. (BOJ15655 - N과 M (6))

## REPACTORING ♻️

### sudo-code

- 중복을 미허용
    - ~~선택된 인덱스 확인 : visited[]~~
    - 선택된 인덱스보다 큰 인덱스 선택, 저장 : r + arr[]
- 순서가 의미 없음
- N개의 원소 입력 : base[]
- 모음의 개수 : count
    
    모음의 개수가 1개 이상이거나, 전체 길이 - 2 미만인 경우 출력
    

## REPORT ✏️

- 현재 선택할 문자가 모음인 경우 count를 늘려주는 방식을 사용하였지만, 재귀를 끝내고 되돌아 왔을 때 count를 줄어들지 않았다. 따라서 if/else로 재귀함수를 호출하는 방식을 사용하였다.

## RESULT 🐧

<img width="625" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/d096cd87-cb71-48e4-bb9a-5249c3711f32">

## TASKS 🔋

- [x]  close #61 
- [x]  Comment
- [ ]  Review
- [ ]  Note