### PR TITLE
BOJ14501 - 퇴사

### DIFF
--- a/src/BruteForce/Recursive/BOJ14501.java
+++ b/src/BruteForce/Recursive/BOJ14501.java
@@ -1,0 +1,45 @@
+package BruteForce.Recursive;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ14501 {
+
+    public static StringBuilder sb = new StringBuilder();
+    public static int N;
+    public static int T[], P[];
+    public static int MAX_PRICE = Integer.MIN_VALUE;
+
+    public static void recursion(int time, int price){
+        //마지막날을 포함해야 하므로 N
+        if(time == N){
+            MAX_PRICE = Math.max(MAX_PRICE, price);
+            return;
+        }
+
+        //해당일의 상담을 시작하는 경우, 넘어가는 경우
+        if(time + T[time] <= N) //상담의 끝이 기간을 초과하지 않을때
+            recursion(time + T[time], price + P[time]); //상담의 끝 날로 이동 + 수입더하기
+        recursion(time + 1, price); //다음날로 이동 + 수입유지
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        T = new int[N];
+        P = new int[N];
+
+        for(int i = 0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            T[i] = Integer.parseInt(st.nextToken());
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+
+        recursion(0,0);
+        System.out.println(MAX_PRICE);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- Back-Tracking

## MINDFLOW 💬

1. 백트래킹 방식으로 조합을 구하는 알고리즘을 사용하여 선택/미선택으로 N일에 상담을 시작하거나 N+1일인 다음날로 넘어가는 두가지로 분류하였다.
2. 마지막날에도 일을 할 수 있으므로 N일이 주어지면 N+1일치의 상담을할 수 있다.

## REPACTORING ♻️

- 기존 방식은 내부에 for 루프를 사용하여 다음 인덱스로 이동하지만 해당문제는 현재 상담을 시작하고 끝나는 날짜로 이동하게 된다. 따라서 for 루프를 사용하지 않아도 된다.

### sudo-code

- 현재날짜의 상담을 하는 경우
    - → 보수 : 기존 보수 + 현재날짜의 보수
    - → 날짜 : 현재 날짜 + 현재날짜의 상담 기간
- 현재날짜의 상담을 하지 않는 경우
    - → 보수 : 기존 보수
    - → 날자 : 현재 날짜 + 1
- N+1일까지 상담 후 최대 보수 출력

## REPORT ✏️

- 다른 풀이를 확인했을 때 DP로 푼 문제들이 많은데 아직 DP를 접근하는 방식을 모르고, 다들 접근하는 방식이 다양해서 이해하기 어려웠다. DP에 익숙해진 다음 다시 풀어봐야겠다.

## RESULT 🐧

<img width="624" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/ed0355d5-9b42-4a15-883d-68a52b3a2d81">

## TASKS 🔋

- [x]  close #62 
- [x]  Comment
- [ ]  Review
- [ ]  Note
- [ ]  DP풀이