### PR TITLE
BOJ1248 - 맞춰봐

### DIFF
--- a/src/BruteForce/Recursive/BOJ1248.java
+++ b/src/BruteForce/Recursive/BOJ1248.java
@@ -1,0 +1,57 @@
+package BruteForce.Recursive;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ1248 {
+
+    public static int N;
+    public static char c[][]; //입력으로 주어지는 문자
+    public static int arr[]; //결과
+
+    public static void permutation(int depth){
+        if(depth == N){
+            for(int val : arr){
+                System.out.print(val + " ");
+            }
+            System.exit(0);
+        }
+
+        for(int i = -10; i<=10; i++){
+            arr[depth] = i;
+            if(check(depth)) {
+                permutation(depth + 1);
+            }
+        }
+    }
+
+    public static boolean check(int depth){
+        int sum = 0;
+        for(int i = depth; i>=0; i--){
+            sum += arr[i];
+            if(c[i][depth] == '+' && sum <= 0) return false;
+            else if(c[i][depth] == '-' && sum >= 0) return false;
+            else if(c[i][depth] == '0' && sum != 0) return false;
+        }
+        return true;
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        c = new char[N][N];
+        arr = new int[N];
+
+        String line = br.readLine();
+        int index = 0;
+        for(int i = 0; i<N; i++){
+            for(int j = i; j<N; j++){
+                c[i][j] = line.charAt(index++);
+            }
+        }
+        permutation(0);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- Back-Tracking
- -10 과 10사이의 정수 중 M개를 중복이 가능하게, 조건에 맞는 수열을 출력 : 중복 순열
- 구간 합

## MINDFLOW 💬

1. 이전 문제를 통해 모든 수열을 고르고 조건을 확인하는 것이 아닌, 수열의 수를 고르기전에 조건을 확인하는 코드를 작성하자
2. 중복이 가능한지 확인하지 못하여 실패하게 되었다.

## REPACTORING ♻️

- 답을 구한 경우 flag를 통해 재귀함수를 빠져나가는 방식 사용 → System.exit(0)을 통해 시스템을 종료하는 방식 사용 : flag를 사용하는 것이 안전하게 종료하는 것 같으나, PS에서는 후자를 사용해도 무방할 것 같다.
- c[i][j]와 비교하기 위해 i부터 j까지의 합을 구하는 반복문을 사용하기 싫었다. 따라서 미리 합을 DP 배열에 저장해놓았다. → 타 풀이를 참고하여 c[N][N] 부터 C[N-1][N] 거꾸로 구간 합을 구한다면 쉽게 비교할 수 있다 : 반복문의 변화를 통해 공간을 줄이게 되었다. (https://gaegosoo.tistory.com/75)

### sudo-code

1. 중복 순열 알고리즘 BOJ15656 - N과 M (7)
    - 중복을 허용
    - 순서가 의미 있으므로 선택한 순서대로 저장 : arr[]
    - 선택된 인덱스를 포함한 모든 인덱스 선택
    - N*N개의 원소 입력 : c[][]

1. c[i][j]는 i부터 j까지의 합의 부호 또는 0으로 저장한 것이다.
    - 첫번째 수를 고른다
        - 인덱스 0 부터 0까지의 합과 c[0][0]를 비교한다.
    - 두번째 수를 고른다
        - 인덱스 1부터 0까지의 합과 c[0][1]을 비교한다
        - 인덱스 1부터 1까지의 합과 c[1][1]을 비교한다.
    - 세번째 수를 고른다
        - 인덱스 2부터 0까지의 합과 c[0][2]를 비교한다.
        - 인덱스 2부터 1까지의 합과 c[1][2]를 비교한다.
        - 인덱스 2부터 2까지의 합과 c[2][2]를 비교한다.
    - N번째 수를 고른다.
        - 인덱스 N 부터 N 까지의 합과 c[N][N]을 비교한다.
        - 인덱스 N-1 부터 N 까지의 합과 c[N-1][N]을 비교한다.
        - …
        - 인덱스 N 부터 0 까지의 합과 c[0][N]을 비교한다.

## REPORT ✏️

- 타 풀이에서 코드가 짧아지는 것은 좋지만 가독성이 떨어지는 부분은 인용하지 않았다. if문이 여러개 있다는 것이 정리가 덜 된 것 같지만 읽기엔 좋은 것 같다.
- sudo-code를 잘 작성하여 이미 부호비교를 마친 인덱스는 검사하지 않도록 하였다. 다만, 행렬로 인해 이중 반복문에 늪에 사로잡혀 for(int j = depth; j≤depth; j++)라는 이상한 코드를 작성하기도 했다.
- 문제에 제약 조건이 없는 경우 모든 경우가 가능하다는 점을 인지해야 한다. 예제만 보지말자.

## RESULT 🐧

<img width="725" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/cd0da4a7-ab67-45e7-9261-d65ee03df24d">

## TASKS 🔋

- [x]  close #66
- [x]  Comment
- [ ]  Review
- [ ]  Note