### PR TITLE
BOJ10819 - 차이를 최대로

### DIFF
--- a/src/BruteForce/Permutation/BOJ10819.java
+++ b/src/BruteForce/Permutation/BOJ10819.java
@@ -1,0 +1,52 @@
+package BruteForce.Permutation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ10819 {
+
+    public static int N;
+    public static int base[];
+    public static int arr[];
+    public static boolean visited[];
+    public static int MAX = Integer.MIN_VALUE;
+
+    public static void permutation(int depth){
+        if(depth == N){
+            int sum = 0;
+            for(int i = 0; i<N-1; i++){
+                sum += Math.abs(arr[i] - arr[i+1]);
+            }
+            MAX = Math.max(MAX, sum);
+            return;
+        }
+
+        for(int i = 0; i<N; i++){
+            if(visited[i]) continue;
+            visited[i] = true;
+            arr[depth] = base[i];
+            permutation(depth + 1);
+            visited[i] = false;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        base = new int[N];
+        arr = new int[N];
+        visited = new boolean[N];
+
+        for(int i = 0; i<N; i++){
+            base[i] = Integer.parseInt(st.nextToken());
+        }
+
+        permutation(0);
+
+        System.out.println(MAX);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- N개의 정수 배열의 순서를 적절히 바꿔 최대값을 출력 : 순열

## MINDFLOW 💬

1. 순열 알고리즘 (BOJ15649 - N과 M (1)) : O(N!)
    
    3 ≤ N ≤ 8 로 최대 40320 제한시간 1초 내로 풀수 있다고 판단
    

## REPACTORING ♻️

### sudo-code

- 순열함수의 종료조건에 도달한 경우 식을 구해준다.

## REPORT ✏️

- 중복에 관한 조건이 없으므로 중복이 생겼을 때의 최적화를 생각해볼 수 있다.  ([https://velog.io/@yanghl98/백준-10819-차이를-최대로](https://velog.io/@yanghl98/%EB%B0%B1%EC%A4%80-10819-%EC%B0%A8%EC%9D%B4%EB%A5%BC-%EC%B5%9C%EB%8C%80%EB%A1%9C))

## RESULT 🐧

<img width="827" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/8e6057eb-bbb5-4708-a0fb-4fdec5b102bc">

## TASKS 🔋

- [x]  close #77 
- [x]  Comment
- [ ]  Review
- [ ]  Note