### PR TITLE
BOJ10971 - 외판원 순회 2

### DIFF
--- a/src/BruteForce/Permutation/BOJ10971.java
+++ b/src/BruteForce/Permutation/BOJ10971.java
@@ -1,0 +1,58 @@
+package BruteForce.Permutation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ10971 {
+
+    public static int N;
+    public static int W[][];
+    public static boolean visited[];
+    public static int arr[];
+    public static int MIN = Integer.MAX_VALUE;
+
+    public static void TSP(int depth, int sum){
+        if(depth == N){
+            //처음으로 되돌아 오는 비용
+            if(W[arr[depth-1]][0] != 0) {
+                MIN = Math.min(MIN, sum + W[arr[depth-1]][arr[0]]);
+            }
+            return;
+        }
+
+        for(int i = 0; i<N; i++){
+            if(visited[i]) continue;
+            if (W[arr[depth-1]][i] != 0) {
+                visited[i] = true;
+                arr[depth] = i;
+                TSP(depth + 1, sum + W[arr[depth-1]][i]);
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        W = new int[N][N];
+        arr = new int[N];
+        visited = new boolean[N];
+
+        for(int i = 0; i<N; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j = 0; j<N; j++){
+                W[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        //첫 번째 도시 선택 : W[i][i]는 항상 0
+        for(int i = 0; i<N; i++){
+            visited[i] = true;
+            TSP(1, 0);
+        }
+
+        System.out.println(MIN);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- N개의 도시를 중복없이 방문하는 경우 : 순열
    - 최소 방문 비용 출력

## MINDFLOW 💬

1. 순열 알고리즘 (BOJ15649 - N과 M (1)) : O(N!)
    
    2 ≤ N ≤ 10 최대 3628800 제한시간 1초 내로 풀수 있다고 판단
    
2. 순열 생성 조건 (BOJ2529 - 부등호)
    
    순열을 생성하고 조건을 확인하는 것이 아닌, 순열을 생성하면서 조건 확인으로 시간을 줄일 수 있음
    

## REPACTORING ♻️

### sudo-code

- 중복을 허용하지 않으므로 선택된 인덱스 확인 : visited[]
- 방문한 도시 개수 변수 : depth

## REPORT ✏️

- 타 풀이로는 방문한 도시 순서를 저장하지 않고 두 개의 변수를 더 사용하여 도시 사이의 비용, 다시 첫번째로 돌아가는 비용을 계산했다. 또한 ArrayIndexOutOfBoundException 을 방지하기 위해 첫번째 원소를 미리 선택했다. ([https://velog.io/@kimmjieun/백준-10971번-외판원-순회-2](https://velog.io/@kimmjieun/%EB%B0%B1%EC%A4%80-10971%EB%B2%88-%EC%99%B8%ED%8C%90%EC%9B%90-%EC%88%9C%ED%9A%8C-2))
- 하지만 재귀함수의 매개변수를 늘리지 않아도 방문한 도시 배열 arr[], 방문한 도시 개수 depth를 통해서 arr[depth-1]로 이전 도시와 arr[0]으로 처음 도시를 알 수 있다. 또한 이전에 푼 부등호 문제를 기반으로 순열을 생성하면서 조건을 확인하여 시간을 줄였다.

## RESULT 🐧

<img width="827" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/1e313f0e-0ac1-4f8d-86dd-35a709f23b38">

## TASKS 🔋

- [x]  close #79
- [x]  Comment
- [ ]  Review
- [ ]  Note