### PR TITLE
BOJ11726 - 2×n 타일링

### DIFF
--- a/src/DynamicProgramming/BOJ11726.java
+++ b/src/DynamicProgramming/BOJ11726.java
@@ -1,0 +1,28 @@
+package DynamicProgramming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ11726 {
+
+    public static int N;
+    public static int dp[];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        dp = new int[N+1];
+
+        dp[0] = 1;
+        dp[1] = 1;
+
+        for(int i = 2; i<dp.length; i++){
+            dp[i] = (dp[i-1] + dp[i-2]) % 10007;
+        }
+
+        System.out.println(dp[N]);
+
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- n을 1과 2의 합으로 나타내는 방법

## MINDFLOW 💬

1. N을 1, 2와 3의 합으로 나타내는 방법 (BOJ9095 - 1,2,3 더하기)

## REPACTORING ♻️

### sudo-code

```
n을 1과 2의 합으로 나타내는 방법
n = 1 : 1 -> 1
n = 2 : 11 2 -> 2
n = 3 : 111 21 12 -> 3
n = 4 : 1111 211 121 112 22 -> 5
n = 5 : 11111 2111 1211 1121 1112 122 212 221 -> 8
```

dp[n] = dp[n-1] + dp[n-2]

## REPORT ✏️

- 나머지 연산이 있다면 나머지 연산의 성질에 대해서 한번 생각해보자. 또한 어느정도 큰 수가 나올 것 같으면 overflow가 발생할 가능성이 높다는 것에 유의해야 한다.
- 작은 N의 값을 넣어가며 점화식을 잘 구성하였지만 N = 1인 경우 ArrayIndexOfOutBoundException이 발생 → dp[1] dp[0] 이 필요하다.

## RESULT 🐧

<img width="827" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/94a7f030-c7a4-40e5-a08d-fc71ca2b5b0d">

## TASKS 🔋

- [x]  close #94 
- [x]  Comment
- [ ]  Review
- [ ]  Note