### PR TITLE
BOJ11727 - 2×n 타일링 2

### DIFF
--- a/src/DynamicProgramming/BOJ11727.java
+++ b/src/DynamicProgramming/BOJ11727.java
@@ -1,0 +1,27 @@
+package DynamicProgramming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ11727 {
+
+    public static int N;
+    public static int dp[];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        dp = new int[1001];
+
+        dp[1] = 1;
+        dp[2] = 3;
+
+        for(int i = 4; i<=N; i++){
+            dp[i] = (dp[i-1] + (dp[i-2] * 2)) % 10007;
+        }
+
+        System.out.println(dp[N]);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- n을 1과 두 가지의 2로 합으로 나타내는 방법

## MINDFLOW 💬

1. n을 1과 2의 합으로 나타내는 방법 (BOJ11726 - 2×n 타일링)
2. N을 1, 2와 3의 합으로 나타내는 방법 (BOJ9095 - 1,2,3 더하기)
3. 점화식을 못찾음 (https://girawhale.tistory.com/34)

## REPACTORING ♻️

### sudo-code

```
n을 1과 두 가지의 2로 합으로 나타내는 방법

n = 1 : 1 -> 1
n = 2 : 11 (2)*2 -> 3
n = 3 : 111 (21 12)*2 -> 5
n = 4 : 1111 (211 121 112)*2 (22) * 4-> 11
n = 5 : 11111 (2111 1211 1121 1112)*2 (221 212 122)*4  -> 21
n = 6 : 111111 (21111 12111 11211 11121 11112)*2 10 (2211, 2121, 2112, 1212, 1122, 1221)*4 24 (222)*8 8 43
```

dp[n] = dp[n-1] + 2 * dp[n-2]

## REPORT ✏️

- 점화식을 세우기 위해 여러 식을 세워보았지만 어려웠다. 따라서 다른 방식, dp를 사용하지 않는 방식을 고민해보았다. 하지만 답을 보니 충분히 생각할 수 있는 식으로 최대한 더 변형해 보아야겠다.

## RESULT 🐧

<img width="827" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/5da6ed06-2adc-44fa-99c1-8043c36e36fa">

## TASKS 🔋

- [x]  close #95
- [x]  Comment
- [ ]  Review
- [ ]  Note