### PR TITLE
solve: 카드 구매하기

### DIFF
--- a/src/DynamicProgramming/BOJ11052.java
+++ b/src/DynamicProgramming/BOJ11052.java
@@ -1,0 +1,35 @@
+package DynamicProgramming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ11052 {
+
+    public static int N;
+    public static int dp[];
+    public static int P[];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        dp = new int[N+1];
+        P = new int[N+1];
+
+        for(int i = 1; i<=N; i++){
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for(int i = 1; i<=N; i++){
+            for(int j = 1; j<=i; j++){
+                dp[i] = Math.max(dp[i], dp[i-j] + P[j]);
+            }
+        }
+
+        System.out.println(dp[N]);
+    }
+}


### PR DESCRIPTION
# TIL

## KEYWORD 🔖

- n개의 카드를 구매하는데 필요한 최대 비용 : 점화식

## MINDFLOW 💬

1. dp문제에 익숙해지자 (https://smartpro.tistory.com/53)

## REPACTORING ♻️

### sudo-code

```
#카드를 1개 구매하는 방법
dp[1] = dp[1] //카드가 1개 있는 카드팩

#카드를 2개 구매하는 방법
dp[2] = Math.max( //의 최대값
dp[1] + P[1], //카드가 1개있는 카드팩 +  
dp[0] + P[2]) //카드가 2개있는 카드팩

#카드를 3개 구매하는 방법
dp[3] = Math.max( //의 최대값
dp[2] + P[1], //카드가 1개있는 카드팩 + 2개 더 구매
dp[1] + P[2], //카드가 2개있는 카드팩 + 1개 더 구매
dp[0] + P[3]) //카드가 3개있는 카드팩

#카드를 4개 구매하는 방법
dp[4] = Math.max(
dp[3] + P[1], //카드가 1개있는 카드팩 + 3개 더 구매
dp[2] + P[2], //카드가 2개있는 카드팩 + 2개 더 구매
dp[1] + P[3], //카드가 3개있는 카드팩 + 1개 더 구매
dp[0] + P[4]) //카드가 4개있는 카드팩

#카드를 N개 구매하는 방법
dp[n] = Math.max(
dp[n], //카드가 n개 있는 카드팩
dp[n-i] + p[i]) //카드가 1..n있는 카드팩 구매 + n-1...0개 더 구매
```

## REPORT ✏️

- 구조를 어느정도 파악했지만 하나의 변수를 사용했고, P[] 배열을 만들지 않고 dp 배열에 한번에 넣게 되어 원하지 않는 답이 나왔다.
- 2개를 구매하고 1개를 더 구매하는 방법과 1개를 구매하고 2개를 더 구매하는 방법은 같지 않다.
- dp[n]을 구하기 위해 여러가지 방법 중 에서 최대값을 저장해야 한다. 따라서 해당 방법을 계산했을 때 항상 기존 값과 비교해야 할것이다.
- Integer 타입의 배열을 생성 시에 null로 초기화 되는 것은 알고 있었다. 하지만 null은 수를 비교할 수 없으므로 오류가 발생한다는 점을 생각하지 못했다.

## RESULT 🐧

<img width="827" alt="image" src="https://github.com/iampingu99/codingInterview/assets/154869950/8808c571-37db-4ed6-b02c-a0deb4fc104a">

## TASKS 🔋

- [x]  close #97 
- [x]  Comment
- [ ]  Review
- [ ]  Note